### PR TITLE
hotfix/category create order update

### DIFF
--- a/server/models/category.py
+++ b/server/models/category.py
@@ -79,3 +79,9 @@ class CategorySerializer(serializers.ModelSerializer):
 
     def get_url_count(self, category):
         return category.urls.count()
+
+    def create(self, validated_data):
+        instance = super().create(validated_data)
+        if instance.order != 1:
+            return Category.objects.move(instance, 1)
+        return instance

--- a/server/v1/test/test_category.py
+++ b/server/v1/test/test_category.py
@@ -365,3 +365,34 @@ class CategoryTest(TestCase):
 
         response = self.client.get('/api/v1/category/', **{'HTTP_AUTHORIZATION': f'JWT {self.access_token}'})
         pprint(response.json())
+
+    def test_new_category_create(self):
+        '''
+        2020.05.29
+        기존에는 카테고리를 추가할 시 가장 마지막 번호로 order가 정해졌는데
+        새로추가되면 order는 1이되고 하위 order들이 1씩 밀리도록 수정
+        '''
+        for i in range(4):
+            params = {
+                "name": f"test_user_1_{i}"
+            }
+            response = self.client.post('/api/v1/category/', params, format='json',
+                                        **{'HTTP_AUTHORIZATION': f'JWT {self.access_token}'})
+            self.assertEqual(response.status_code, 201)
+
+        response = self.client.get('/api/v1/category/', **{'HTTP_AUTHORIZATION': f'JWT {self.access_token}'})
+        pprint(response.json())
+        self.assertEqual(response.status_code, 200)
+
+        print("다른 user########################################################\n\n")
+
+        for i in range(4):
+            params = {
+                "name": f"test_user_2_{i}"
+            }
+            response = self.client.post('/api/v1/category/', params, format='json',
+                                        **{'HTTP_AUTHORIZATION': f'JWT {self.access_token2}'})
+            self.assertEqual(response.status_code, 201)
+        response = self.client.get('/api/v1/category/', **{'HTTP_AUTHORIZATION': f'JWT {self.access_token2}'})
+        pprint(response.json())
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
카테고리 생성시 기존에는 맨마지막 order로 추가되었지만, 1로 설정되고 1번부터 +1씩 되도록 수정